### PR TITLE
Add delegation token audit metadata to activities

### DIFF
--- a/aws-dynamodb/src/main/java/com/formkiq/aws/dynamodb/useractivities/ActivityRecord.java
+++ b/aws-dynamodb/src/main/java/com/formkiq/aws/dynamodb/useractivities/ActivityRecord.java
@@ -39,8 +39,8 @@ public record ActivityRecord(DynamoDbShardKey key, String resource, UserActivity
     String classificationId, String mappingId, String rulesetId, String ruleId, String entityTypeId,
     String entityId, String documentId, String artifactId, String workflowId, String attributeKey,
     String queueId, String webhookId, String locale, String apiKey, String controlPolicy,
-    String message, Date insertedDate, String versionPk, String versionSk,
-    Map<String, Object> changes) {
+    String message, String delegationUsedByUserId, String delegationReason, Date insertedDate,
+    String versionPk, String versionSk, Map<String, Object> changes) {
 
   /**
    * Canonical constructor to enforce non-null properties and defensive copy of Date.
@@ -66,14 +66,15 @@ public record ActivityRecord(DynamoDbShardKey key, String resource, UserActivity
         .withString("type", type.name()).withString("status", status.name())
         .withString("sourceIpAddress", sourceIpAddress).withString("source", source)
         .withString("userId", userId).withString("message", message).withString("schema", schema)
-        .withString("mappingId", mappingId).withString("classificationId", classificationId)
-        .withString("entityTypeId", entityTypeId).withString("entityId", entityId)
-        .withString("rulesetId", rulesetId).withString("ruleId", ruleId)
-        .withString("apiKey", apiKey).withString("documentId", documentId)
-        .withString("artifactId", artifactId).withString("controlPolicy", controlPolicy)
-        .withString("workflowId", workflowId).withString("attributeKey", attributeKey)
-        .withString("queueId", queueId).withString("webhookId", webhookId)
-        .withString("locale", locale).withDate("inserteddate", insertedDate)
-        .withMap("changes", changes).build();
+        .withString("delegationUsedByUserId", delegationUsedByUserId)
+        .withString("delegationReason", delegationReason).withString("mappingId", mappingId)
+        .withString("classificationId", classificationId).withString("entityTypeId", entityTypeId)
+        .withString("entityId", entityId).withString("rulesetId", rulesetId)
+        .withString("ruleId", ruleId).withString("apiKey", apiKey)
+        .withString("documentId", documentId).withString("artifactId", artifactId)
+        .withString("controlPolicy", controlPolicy).withString("workflowId", workflowId)
+        .withString("attributeKey", attributeKey).withString("queueId", queueId)
+        .withString("webhookId", webhookId).withString("locale", locale)
+        .withDate("inserteddate", insertedDate).withMap("changes", changes).build();
   }
 }

--- a/aws-dynamodb/src/main/java/com/formkiq/aws/dynamodb/useractivities/ActivityRecordBuilder.java
+++ b/aws-dynamodb/src/main/java/com/formkiq/aws/dynamodb/useractivities/ActivityRecordBuilder.java
@@ -86,6 +86,10 @@ public class ActivityRecordBuilder implements DynamoDbShardEntityBuilder<Activit
   private String attributeKey;
   /** Activity Message. */
   private String message;
+  /** Delegation Used By UserId. */
+  private String delegationUsedByUserId;
+  /** Delegation Reason. */
+  private String delegationReason;
   /** Activity Inserted Date. */
   private Date insertedDate = new Date();
   /** Activity Changes. */
@@ -147,7 +151,8 @@ public class ActivityRecordBuilder implements DynamoDbShardEntityBuilder<Activit
     return new ActivityRecord(key, resource, type, status, sourceIpAddress, source, userId, schema,
         classificationId, mappingId, rulesetId, ruleId, entityTypeId, entityId, documentId,
         artifactId, workflowId, attributeKey, queueId, webhookId, locale, apiKey, controlPolicy,
-        message, insertedDate, versionPk, versionSk, changes);
+        message, delegationUsedByUserId, delegationReason, insertedDate, versionPk, versionSk,
+        changes);
   }
 
   private DynamoDbShardKey buildActivityKey(final String siteId, final String pk,
@@ -360,6 +365,28 @@ public class ActivityRecordBuilder implements DynamoDbShardEntityBuilder<Activit
    */
   public ActivityRecordBuilder changes(final Map<String, Object> activityChanges) {
     this.changes = activityChanges;
+    return this;
+  }
+
+  /**
+   * Sets the reason for delegated activity.
+   *
+   * @param activityDelegationReason reason for delegation
+   * @return this Builder
+   */
+  public ActivityRecordBuilder delegationReason(final String activityDelegationReason) {
+    this.delegationReason = activityDelegationReason;
+    return this;
+  }
+
+  /**
+   * Sets the user ID that used delegated activity.
+   *
+   * @param activityDelegationUsedByUserId user ID that used delegation
+   * @return this Builder
+   */
+  public ActivityRecordBuilder delegationUsedByUserId(final String activityDelegationUsedByUserId) {
+    this.delegationUsedByUserId = activityDelegationUsedByUserId;
     return this;
   }
 

--- a/aws-dynamodb/src/test/java/com/formkiq/aws/dynamodb/useractivities/ActivityRecordBuilderTest.java
+++ b/aws-dynamodb/src/test/java/com/formkiq/aws/dynamodb/useractivities/ActivityRecordBuilderTest.java
@@ -26,6 +26,7 @@ package com.formkiq.aws.dynamodb.useractivities;
 import com.formkiq.aws.dynamodb.DynamoDbKey;
 import com.formkiq.aws.dynamodb.DynamoDbShardKey;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -75,6 +76,22 @@ public class ActivityRecordBuilderTest {
 
   private void assertKeyEquals(final String siteId, final String expectedKey, final String gotKey) {
     assertEquals(siteId != null ? siteId + "/" + expectedKey : expectedKey, gotKey);
+  }
+
+  @Test
+  void testBuildDelegationMetadata() {
+    ActivityRecord record = new ActivityRecordBuilder("", "").resource("documents")
+        .resourceIds(Map.of("documentId", "doc-1")).userId(USER_ID)
+        .delegationUsedByUserId("admin@example.com").delegationReason("Support case 123")
+        .type(UserActivityType.CREATE).status(UserActivityStatus.COMPLETE)
+        .insertedDate(INSERTED_DATE).build(SITE_ID);
+
+    Map<String, AttributeValue> attributes = record.getAttributes();
+
+    assertEquals("admin@example.com", record.delegationUsedByUserId());
+    assertEquals("Support case 123", record.delegationReason());
+    assertEquals("admin@example.com", attributes.get("delegationUsedByUserId").s());
+    assertEquals("Support case 123", attributes.get("delegationReason").s());
   }
 
   @Test

--- a/docs/openapi/openapi-iam.yaml
+++ b/docs/openapi/openapi-iam.yaml
@@ -7257,7 +7257,7 @@ paths:
         expiresInSeconds. When expiresInSeconds is not set, the token does not expire. When
         onBehalfOf is supplied, activity created while using the token is attributed to that
         username while the signed token still records the ADMIN principal that issued it. The
-        optional reason is signed into the token for audit and support traceability.
+        reason is signed into the token for audit and support traceability.
       summary: Generate a delegation token
       tags:
       - System Management
@@ -8731,6 +8731,8 @@ components:
         userId:
           type: string
           description: User who added document
+        delegation:
+          $ref: '#/components/schemas/ActivityDelegation'
         documentId:
           description: Document Identifier
         artifactId:
@@ -8780,6 +8782,15 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/UserActivityChanges'
+    ActivityDelegation:
+      type: object
+      properties:
+        usedByUserId:
+          type: string
+          description: User who used the delegation token for the activity
+        reason:
+          type: string
+          description: Reason supplied when the delegation token was generated
     GetAttributesResponse:
       type: object
       properties:
@@ -14616,6 +14627,7 @@ components:
       type: object
       required:
       - permissions
+      - reason
       properties:
         permissions:
           type: array

--- a/docs/openapi/openapi-jwt.yaml
+++ b/docs/openapi/openapi-jwt.yaml
@@ -7257,7 +7257,7 @@ paths:
         expiresInSeconds. When expiresInSeconds is not set, the token does not expire. When
         onBehalfOf is supplied, activity created while using the token is attributed to that
         username while the signed token still records the ADMIN principal that issued it. The
-        optional reason is signed into the token for audit and support traceability.
+        reason is signed into the token for audit and support traceability.
       summary: Generate a delegation token
       tags:
       - System Management
@@ -8731,6 +8731,8 @@ components:
         userId:
           type: string
           description: User who added document
+        delegation:
+          $ref: '#/components/schemas/ActivityDelegation'
         documentId:
           description: Document Identifier
         artifactId:
@@ -8780,6 +8782,15 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/UserActivityChanges'
+    ActivityDelegation:
+      type: object
+      properties:
+        usedByUserId:
+          type: string
+          description: User who used the delegation token for the activity
+        reason:
+          type: string
+          description: Reason supplied when the delegation token was generated
     GetAttributesResponse:
       type: object
       properties:
@@ -14616,6 +14627,7 @@ components:
       type: object
       required:
       - permissions
+      - reason
       properties:
         permissions:
           type: array

--- a/docs/openapi/openapi-key.yaml
+++ b/docs/openapi/openapi-key.yaml
@@ -7257,7 +7257,7 @@ paths:
         expiresInSeconds. When expiresInSeconds is not set, the token does not expire. When
         onBehalfOf is supplied, activity created while using the token is attributed to that
         username while the signed token still records the ADMIN principal that issued it. The
-        optional reason is signed into the token for audit and support traceability.
+        reason is signed into the token for audit and support traceability.
       summary: Generate a delegation token
       tags:
       - System Management
@@ -8731,6 +8731,8 @@ components:
         userId:
           type: string
           description: User who added document
+        delegation:
+          $ref: '#/components/schemas/ActivityDelegation'
         documentId:
           description: Document Identifier
         artifactId:
@@ -8780,6 +8782,15 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/UserActivityChanges'
+    ActivityDelegation:
+      type: object
+      properties:
+        usedByUserId:
+          type: string
+          description: User who used the delegation token for the activity
+        reason:
+          type: string
+          description: Reason supplied when the delegation token was generated
     GetAttributesResponse:
       type: object
       properties:
@@ -14616,6 +14627,7 @@ components:
       type: object
       required:
       - permissions
+      - reason
       properties:
         permissions:
           type: array

--- a/fkq-plugins/src/main/java/com/formkiq/plugins/useractivity/UserActivity.java
+++ b/fkq-plugins/src/main/java/com/formkiq/plugins/useractivity/UserActivity.java
@@ -46,6 +46,12 @@ public record UserActivity(
     /* The identifier of the user who performed the activity. */
     String userId,
 
+    /* The identifier of the user who used delegated activity. */
+    String delegationUsedByUserId,
+
+    /* The reason supplied for delegated activity. */
+    String delegationReason,
+
     /* The timestamp when the activity was recorded. */
     Date insertedDate,
 
@@ -85,6 +91,10 @@ public record UserActivity(
     private UserActivityType type;
     /** User Id. */
     private String userId;
+    /** Delegation Used By UserId. */
+    private String delegationUsedByUserId;
+    /** Delegation Reason. */
+    private String delegationReason;
     /** Inserted Date. */
     private Instant insertedDate;
     /** Activity Message. */
@@ -117,12 +127,23 @@ public record UserActivity(
      * @return a new {@link UserActivity} object
      */
     public UserActivity build(final String siteId) {
-      return new UserActivity(siteId, resource, type, userId, Date.from(insertedDate), message,
-          status, sourceIpAddress, source, resourceIds, body, changes);
+      return new UserActivity(siteId, resource, type, userId, delegationUsedByUserId,
+          delegationReason, Date.from(insertedDate), message, status, sourceIpAddress, source,
+          resourceIds, body, changes);
     }
 
     public Builder changes(final Map<String, ChangeRecord> userActivityChanges) {
       this.changes = userActivityChanges;
+      return this;
+    }
+
+    public Builder delegationReason(final String userActivityDelegationReason) {
+      this.delegationReason = userActivityDelegationReason;
+      return this;
+    }
+
+    public Builder delegationUsedByUserId(final String userActivityDelegationUsedByUserId) {
+      this.delegationUsedByUserId = userActivityDelegationUsedByUserId;
       return this;
     }
 

--- a/src/main/resources/cloudformation/api/partials/paths/activities.yaml
+++ b/src/main/resources/cloudformation/api/partials/paths/activities.yaml
@@ -239,6 +239,8 @@ components:
         userId:
           type: string
           description: User who added document
+        delegation:
+          $ref: '#/components/schemas/ActivityDelegation'
         documentId:
           description: Document Identifier
         artifactId:
@@ -288,3 +290,13 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/UserActivityChanges'
+    #@overlay/match missing_ok=True
+    ActivityDelegation:
+      type: object
+      properties:
+        usedByUserId:
+          type: string
+          description: User who used the delegation token for the activity
+        reason:
+          type: string
+          description: Reason supplied when the delegation token was generated

--- a/src/main/resources/cloudformation/api/partials/paths/sites_delegation_tokens.yaml
+++ b/src/main/resources/cloudformation/api/partials/paths/sites_delegation_tokens.yaml
@@ -15,7 +15,7 @@ paths:
         expiresInSeconds. When expiresInSeconds is not set, the token does not expire. When
         onBehalfOf is supplied, activity created while using the token is attributed to that
         username while the signed token still records the ADMIN principal that issued it. The
-        optional reason is signed into the token for audit and support traceability.
+        reason is signed into the token for audit and support traceability.
       summary: Generate a delegation token
       tags:
         - System Management
@@ -60,6 +60,7 @@ components:
       type: object
       required:
         - permissions
+        - reason
       properties:
         permissions:
           type: array


### PR DESCRIPTION
- Add delegationUsedByUserId and delegationReason to activity records
- Expose activity delegation details as a nested OpenAPI object
- Require reason when generating delegation tokens
- Document optional delegation token expiry behavior