### PR TITLE
Add document artifact metadata support

### DIFF
--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/attributes/AttributeKeyReserved.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/attributes/AttributeKeyReserved.java
@@ -39,6 +39,8 @@ public enum AttributeKeyReserved {
   MALWARE_SCAN_RESULT("MalwareScanResult"),
   /** Relationships. */
   RELATIONSHIPS("Relationships"),
+  /** Artifact Status. */
+  ARTIFACT_STATUS("ArtifactStatus"),
   /** Checkout. */
   CHECKOUT("Checkout"),
   /** CheckoutForLegalHold. */

--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentItemToDocumentRecordBuilder.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentItemToDocumentRecordBuilder.java
@@ -63,6 +63,6 @@ public class DocumentItemToDocumentRecordBuilder
         .s3version(item.getS3version()).userId(item.getUserId()).version(item.getVersion())
         .width(item.getWidth()).height(item.getHeight()).timeToLive(item.getTimeToLive())
         .insertedDate(item.getInsertedDate()).lastModifiedDate(item.getLastModifiedDate())
-        .metadata(item.getMetadata());
+        .metadata(item.getMetadata()).hasArtifacts(item.getHasArtifacts());
   }
 }

--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentRecord.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentRecord.java
@@ -40,7 +40,7 @@ public record DocumentRecord(DynamoDbKey key, String documentId, String artifact
     String belongsToDocumentId, String path, String deepLinkPath, String contentType,
     Long contentLength, String checksum, String checksumType, String s3version, String userId,
     String version, String width, String height, String timeToLive, Date insertedDate,
-    Date lastModifiedDate, Collection<DocumentMetadata> metadata) {
+    Date lastModifiedDate, Collection<DocumentMetadata> metadata, Boolean hasArtifacts) {
 
   /**
    * Canonical constructor to enforce non-null properties and defensive copy of Date fields.
@@ -48,6 +48,10 @@ public record DocumentRecord(DynamoDbKey key, String documentId, String artifact
   public DocumentRecord {
     Objects.requireNonNull(key, "key must not be null");
     Objects.requireNonNull(documentId, "documentId must not be null");
+
+    if (artifactId != null) {
+      hasArtifacts = Boolean.FALSE;
+    }
 
     if (insertedDate != null) {
       insertedDate = new Date(insertedDate.getTime());
@@ -92,7 +96,10 @@ public record DocumentRecord(DynamoDbKey key, String documentId, String artifact
         DynamoDbTypes.toString(attributes.get("height")),
         DynamoDbTypes.toString(attributes.get("timeToLive")),
         DynamoDbTypes.toDate(attributes.get("inserteddate")),
-        DynamoDbTypes.toDate(attributes.get("lastModifiedDate")), metadata);
+        DynamoDbTypes.toDate(attributes.get("lastModifiedDate")), metadata,
+        attributes.containsKey("hasArtifacts")
+            ? DynamoDbTypes.toBoolean(attributes.get("hasArtifacts"))
+            : null);
   }
 
   /**
@@ -117,7 +124,7 @@ public record DocumentRecord(DynamoDbKey key, String documentId, String artifact
         .withString("userId", userId).withString("version", version).withString("width", width)
         .withString("height", height).withNumber("TimeToLive", timeToLive)
         .withDate("inserteddate", insertedDate).withDate("lastModifiedDate", lastModifiedDate)
-        .withMap(metadataAttrs);
+        .withMap(metadataAttrs).withBoolean("hasArtifacts", hasArtifacts);
 
     return map.build();
   }

--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentRecordBuilder.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentRecordBuilder.java
@@ -87,6 +87,8 @@ public class DocumentRecordBuilder implements DynamoDbEntityBuilder<DocumentReco
   private Date lastModifiedDate;
   /** {@link DocumentMetadata}. */
   private Collection<DocumentMetadata> metadata;
+  /** Whether this non-artifact document has artifact documents. */
+  private Boolean hasArtifacts;
   /** Metadata Keys to Delete. */
   private Collection<String> metadataDeleteKeys = Collections.emptyList();
   /** Set GSI1. */
@@ -146,13 +148,18 @@ public class DocumentRecordBuilder implements DynamoDbEntityBuilder<DocumentReco
         defaultValues != null ? defaultValues.getAttributes() : Collections.emptyMap();
 
     String cs = ps(checksum, prev, "checksum");
+    Boolean ha = hasArtifacts;
+    if (ha == null && prev.containsKey("hasArtifacts")) {
+      ha = DynamoDbTypes.toBoolean(prev.get("hasArtifacts"));
+    }
     return new DocumentRecord(key, documentId, ps(artifactId, prev, "artifactId"),
         ps(belongsToDocumentId, prev, "belongsToDocumentId"), ps(path, prev, "path"), deepLinkPath,
         ps(contentType, prev, "contentType"), ps(contentLength, prev, "contentLength"),
         cs != null ? removeQuotes(cs) : null, ps(checksumType, prev, "checksumType"),
         ps(s3version, prev, "s3version"), ps(userId, prev, "userId"), ps(version, prev, "version"),
         ps(width, prev, "width"), ps(height, prev, "height"), ps(timeToLive, prev, "TimeToLive"),
-        insertedDate, lastModifiedDate, documentMetadata);
+        insertedDate, lastModifiedDate, documentMetadata,
+        !isEmpty(ps(artifactId, prev, "artifactId")) ? Boolean.FALSE : ha);
   }
 
   @Override
@@ -289,6 +296,11 @@ public class DocumentRecordBuilder implements DynamoDbEntityBuilder<DocumentReco
    */
   public DocumentRecordBuilder gsi1(final boolean setGsi1) {
     this.gsi1 = setGsi1;
+    return this;
+  }
+
+  public DocumentRecordBuilder hasArtifacts(final Boolean value) {
+    this.hasArtifacts = value;
     return this;
   }
 

--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentRecordToDocumentRecordBuilder.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/documents/DocumentRecordToDocumentRecordBuilder.java
@@ -54,6 +54,7 @@ public class DocumentRecordToDocumentRecordBuilder
         .checksumType(record.checksumType()).s3version(record.s3version()).userId(record.userId())
         .version(record.version()).width(record.width()).height(record.height())
         .timeToLive(record.timeToLive()).insertedDate(record.insertedDate())
-        .lastModifiedDate(record.lastModifiedDate()).metadata(record.metadata());
+        .lastModifiedDate(record.lastModifiedDate()).metadata(record.metadata())
+        .hasArtifacts(record.hasArtifacts());
   }
 }

--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/model/DocumentItem.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/model/DocumentItem.java
@@ -96,6 +96,13 @@ public interface DocumentItem {
   List<DocumentItem> getDocuments();
 
   /**
+   * Whether this non-artifact document has artifact documents.
+   *
+   * @return {@link Boolean}
+   */
+  Boolean getHasArtifacts();
+
+  /**
    * Get Height.
    *
    * @return {@link String}
@@ -227,6 +234,13 @@ public interface DocumentItem {
    * @param ids {@link List} {@link DocumentItem}
    */
   void setDocuments(List<DocumentItem> ids);
+
+  /**
+   * Set whether this non-artifact document has artifact documents.
+   *
+   * @param hasArtifacts {@link Boolean}
+   */
+  void setHasArtifacts(Boolean hasArtifacts);
 
   /**
    * Set Height.

--- a/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/model/DynamicDocumentItem.java
+++ b/adapters/aws/dynamodb/src/main/java/com/formkiq/aws/dynamodb/model/DynamicDocumentItem.java
@@ -100,6 +100,11 @@ public class DynamicDocumentItem extends DynamicObject implements DocumentItem {
   }
 
   @Override
+  public Boolean getHasArtifacts() {
+    return (Boolean) get("hasArtifacts");
+  }
+
+  @Override
   public String getHeight() {
     return getString("height");
   }
@@ -169,6 +174,9 @@ public class DynamicDocumentItem extends DynamicObject implements DocumentItem {
   @Override
   public void setArtifactId(final String artifactId) {
     put("artifactId", artifactId);
+    if (artifactId != null) {
+      put("hasArtifacts", Boolean.FALSE);
+    }
   }
 
   @Override
@@ -210,6 +218,15 @@ public class DynamicDocumentItem extends DynamicObject implements DocumentItem {
   public void setDocuments(final List<DocumentItem> list) {
     put("documents", list);
 
+  }
+
+  @Override
+  public void setHasArtifacts(final Boolean hasArtifacts) {
+    if (getArtifactId() == null) {
+      put("hasArtifacts", hasArtifacts);
+    } else {
+      put("hasArtifacts", Boolean.FALSE);
+    }
   }
 
   @Override

--- a/adapters/aws/dynamodb/src/test/java/com/formkiq/aws/dynamodb/attributes/AttributeKeyReservedTest.java
+++ b/adapters/aws/dynamodb/src/test/java/com/formkiq/aws/dynamodb/attributes/AttributeKeyReservedTest.java
@@ -1,0 +1,42 @@
+/**
+ * MIT License
+ * 
+ * Copyright (c) 2018 - 2020 FormKiQ
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.formkiq.aws.dynamodb.attributes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link AttributeKeyReserved}.
+ */
+class AttributeKeyReservedTest {
+
+  @Test
+  void testFindArtifactStatus() {
+    assertEquals(AttributeKeyReserved.ARTIFACT_STATUS, AttributeKeyReserved.find("artifactstatus"));
+    assertEquals("ArtifactStatus", AttributeKeyReserved.ARTIFACT_STATUS.getKey());
+    assertEquals(AttributeType.STANDARD, AttributeKeyReserved.ARTIFACT_STATUS.getType());
+    assertEquals(AttributeDataType.STRING, AttributeKeyReserved.ARTIFACT_STATUS.getDataType());
+  }
+}

--- a/adapters/aws/dynamodb/src/test/java/com/formkiq/aws/dynamodb/documents/DocumentRecordBuilderTest.java
+++ b/adapters/aws/dynamodb/src/test/java/com/formkiq/aws/dynamodb/documents/DocumentRecordBuilderTest.java
@@ -24,6 +24,7 @@
 package com.formkiq.aws.dynamodb.documents;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.formkiq.aws.dynamodb.DynamoDbKey;
@@ -39,6 +40,24 @@ public class DocumentRecordBuilderTest {
 
   private void assertKeyEquals(final String siteId, final String expected, final String actual) {
     assertEquals(siteId != null ? siteId + "/" + expected : expected, actual);
+  }
+
+  @Test
+  void testBuildHasArtifacts01() {
+    DocumentRecord record = new DocumentRecordBuilder().documentId(ID.uuid())
+        .hasArtifacts(Boolean.TRUE).build((String) null);
+
+    assertTrue(record.hasArtifacts());
+    assertTrue(record.getAttributes().get("hasArtifacts").bool());
+  }
+
+  @Test
+  void testBuildHasArtifacts02() {
+    DocumentRecord record = new DocumentRecordBuilder().documentId(ID.uuid()).artifactId(ID.ulid())
+        .hasArtifacts(Boolean.TRUE).build((String) null);
+
+    assertFalse(record.hasArtifacts());
+    assertFalse(record.getAttributes().get("hasArtifacts").bool());
   }
 
   @Test

--- a/apps/lambda-api/src/test/java/com/formkiq/stacks/api/handler/DocumentsIdRequestTest.java
+++ b/apps/lambda-api/src/test/java/com/formkiq/stacks/api/handler/DocumentsIdRequestTest.java
@@ -203,8 +203,6 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
   private List<Document> getDocuments(final String siteId) throws ApiException {
     return notNull(new GetDocumentsRequestBuilder().submit(client, siteId).throwIfError().response()
         .getDocuments());
-    // return notNull(this.documentsApi
-    // .getDocuments(siteId, null, null, null, null, null, null, null, null, null).getDocuments());
   }
 
   private List<Document> getDocuments(final String siteId, final int expected)
@@ -222,8 +220,6 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
   private List<Document> getSoftDeletedDocuments(final String siteId) throws ApiException {
     return notNull(new GetDocumentsRequestBuilder().deleted(true).submit(client, siteId)
         .throwIfError().response().getDocuments());
-    // return notNull(this.documentsApi
-    // .getDocuments(siteId, null, null, TRUE, null, null, null, null, null, null).getDocuments());
   }
 
   private String getTagValue(final String siteId, final DocumentArtifact artifact) {
@@ -334,7 +330,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
       // then
       List<Document> softDeletedDocuments = getSoftDeletedDocuments(siteId);
       assertEquals(1, softDeletedDocuments.size());
-      assertEquals(document.documentId(), softDeletedDocuments.get(0).getDocumentId());
+      assertEquals(document.documentId(), softDeletedDocuments.getFirst().getDocumentId());
 
       List<Document> documents = getDocuments(siteId);
       assertEquals(0, documents.size());
@@ -421,7 +417,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
 
       docs = searchDocumentAttribute(siteId, attributeKey, "1");
       assertEquals(1, docs.size());
-      assertEquals(document1.documentId(), docs.get(0).getDocumentId());
+      assertEquals(document1.documentId(), docs.getFirst().getDocumentId());
 
       // when - restore document
       this.documentsApi.setDocumentRestore(document0.documentId(), siteId, document0.artifactId());
@@ -447,19 +443,29 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
       String path0 = ID.ulid() + ".txt";
       String path1 = ID.ulid() + ".txt";
 
+      // when
       AddDocumentResponse document = new AddDocumentRequestBuilder().content().path(path0)
           .submit(client, siteId).throwIfError().response();
 
       AddDocumentResponse addArtifact =
           new AddDocumentRequestBuilder().documentId(document.getDocumentId()).content().path(path1)
               .artifacts(true).submit(client, siteId).throwIfError().response();
+
+      // then
       DocumentArtifact artifact =
           DocumentArtifact.of(addArtifact.getDocumentId(), addArtifact.getArtifactId());
 
       assertNotNull(document.getDocumentId());
       assertNotNull(artifact.artifactId());
-      assertNotNull(getDocument(siteId, document.getDocumentId()).throwIfError().response());
-      assertNotNull(getDocument(siteId, artifact).throwIfError().response());
+
+      GetDocumentResponse baseDocument =
+          getDocument(siteId, document.getDocumentId()).throwIfError().response();
+      GetDocumentResponse artifactDocument =
+          getDocument(siteId, artifact).throwIfError().response();
+      assertNotNull(baseDocument);
+      assertNotNull(artifactDocument);
+      assertEquals(Boolean.TRUE, baseDocument.getHasArtifacts());
+      assertEquals(Boolean.FALSE, artifactDocument.getHasArtifacts());
 
       // when
       this.documentsApi.deleteDocument(document.getDocumentId(), siteId, artifact.artifactId(),
@@ -469,7 +475,9 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
       List<Document> softDeletedDocuments = getSoftDeletedDocuments(siteId);
       assertEquals(0, softDeletedDocuments.size());
 
-      assertNotNull(getDocument(siteId, document.getDocumentId()).throwIfError().response());
+      baseDocument = getDocument(siteId, document.getDocumentId()).throwIfError().response();
+      assertNotNull(baseDocument);
+      assertEquals(Boolean.FALSE, baseDocument.getHasArtifacts());
 
       ApiHttpResponse<GetDocumentResponse> artifactResponse = getDocument(siteId, artifact);
       assertNotNull(artifactResponse.exception());
@@ -516,8 +524,8 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
 
       List<Document> softDeletedDocuments = getSoftDeletedDocuments(siteId);
       assertEquals(1, softDeletedDocuments.size());
-      assertEquals(artifact.documentId(), softDeletedDocuments.get(0).getDocumentId());
-      assertEquals(artifact.artifactId(), softDeletedDocuments.get(0).getArtifactId());
+      assertEquals(artifact.documentId(), softDeletedDocuments.getFirst().getDocumentId());
+      assertEquals(artifact.artifactId(), softDeletedDocuments.getFirst().getArtifactId());
 
 
       // when
@@ -525,8 +533,8 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
 
       // then
       assertEquals(1, list.size());
-      assertEquals(document.documentId(), list.get(0).getDocumentId());
-      assertNull(list.get(0).getArtifactId());
+      assertEquals(document.documentId(), list.getFirst().getDocumentId());
+      assertNull(list.getFirst().getArtifactId());
 
       // when
       new RestoreDocumentRequestBuilder(artifact).submit(client, siteId).throwIfError();
@@ -605,10 +613,9 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
   /**
    * POST /documents request, with workflow-only DELETE action.
    *
-   * @throws Exception an error has occurred
    */
   @Test
-  public void testHandleAddDocumentDelete01() throws Exception {
+  public void testHandleAddDocumentDelete01() {
     // given
     for (String siteId : Arrays.asList(null, ID.uuid())) {
       setBearerToken(siteId);
@@ -633,10 +640,9 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
   /**
    * POST /documents request, with workflow-only MOVE action.
    *
-   * @throws Exception an error has occurred
    */
   @Test
-  public void testHandleAddDocumentMove01() throws Exception {
+  public void testHandleAddDocumentMove01() {
     // given
     for (String siteId : Arrays.asList(null, ID.uuid())) {
       setBearerToken(siteId);
@@ -764,7 +770,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
       // then
       List<Document> softDeletedDocuments = getSoftDeletedDocuments(siteId);
       assertEquals(1, softDeletedDocuments.size());
-      assertEquals(path, softDeletedDocuments.get(0).getPath());
+      assertEquals(path, softDeletedDocuments.getFirst().getPath());
 
       List<Document> documents = getDocuments(siteId, 0);
       assertEquals(0, documents.size());
@@ -779,7 +785,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
       assertEquals(0, softDeletedDocuments.size());
       documents = getDocuments(siteId, 1);
       assertEquals(1, documents.size());
-      assertEquals(path, documents.get(0).getPath());
+      assertEquals(path, documents.getFirst().getPath());
     }
   }
 
@@ -892,7 +898,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
       List<DocumentAction> actions = notNull(this.documentActionsApi
           .getDocumentActions(documentId, siteId, null, null, null, null).getActions());
       assertEquals(1, actions.size());
-      assertEquals(DocumentActionType.FULLTEXT, actions.get(0).getType());
+      assertEquals(DocumentActionType.FULLTEXT, actions.getFirst().getType());
     }
   }
 
@@ -1392,7 +1398,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
 
       List<SearchResultDocument> docs = search(siteId, sreq);
       assertEquals(1, docs.size());
-      assertEquals(path0, docs.get(0).getPath());
+      assertEquals(path0, docs.getFirst().getPath());
 
       // given
       UpdateDocumentRequest updateReq = new UpdateDocumentRequest().path(path1);
@@ -1405,7 +1411,7 @@ public class DocumentsIdRequestTest extends AbstractApiClientRequestTest {
 
       docs = search(siteId, sreq);
       assertEquals(1, docs.size());
-      assertEquals(path1, docs.get(0).getPath());
+      assertEquals(path1, docs.getFirst().getPath());
     }
   }
 

--- a/apps/lambda-api/src/test/java/com/formkiq/stacks/api/handler/DocumentsRequestTest.java
+++ b/apps/lambda-api/src/test/java/com/formkiq/stacks/api/handler/DocumentsRequestTest.java
@@ -1323,6 +1323,8 @@ public class DocumentsRequestTest extends AbstractApiClientRequestTest {
       // then
       assertNotNull(resp.response());
       String documentId = resp.response().getDocumentId();
+      assertEquals(Boolean.FALSE, new GetDocumentRequestBuilder(documentId).submit(client, siteId)
+          .throwIfError().response().getHasArtifacts());
 
       // when
       resp =
@@ -1333,11 +1335,17 @@ public class DocumentsRequestTest extends AbstractApiClientRequestTest {
       assertEquals(documentId, resp.response().getDocumentId());
       String artifactId = resp.response().getArtifactId();
       assertNotNull(artifactId);
-      DocumentArtifact artifact = DocumentArtifact.of(documentId, artifactId);
 
+      assertEquals(Boolean.TRUE, new GetDocumentRequestBuilder(documentId).submit(client, siteId)
+          .throwIfError().response().getHasArtifacts());
+
+      DocumentArtifact artifact = DocumentArtifact.of(documentId, artifactId);
       var doc = new GetDocumentRequestBuilder(artifact).submit(client, siteId).throwIfError();
       assertEquals(path1, doc.response().getPath());
       assertEquals(artifactId, doc.response().getArtifactId());
+      assertEquals(Boolean.FALSE, doc.response().getHasArtifacts());
+      assertEquals(Boolean.TRUE, new GetDocumentRequestBuilder(documentId).submit(client, siteId)
+          .throwIfError().response().getHasArtifacts());
 
       // when
       var content = new GetDocumentContentRequestBuilder(documentId).setArtifactId(artifactId)
@@ -1355,6 +1363,7 @@ public class DocumentsRequestTest extends AbstractApiClientRequestTest {
       List<Document> documents = notNull(artifacts.response().getDocuments());
       assertEquals(1, documents.size());
       assertEquals(path1, documents.getFirst().getPath());
+      assertEquals(Boolean.FALSE, documents.getFirst().getHasArtifacts());
 
       var baseFolderDocuments = getFilesInFolder(siteId, folder0);
       assertEquals(1, baseFolderDocuments.size());
@@ -1448,6 +1457,7 @@ public class DocumentsRequestTest extends AbstractApiClientRequestTest {
             new GetDocumentRequestBuilder(documentId).submit(client, siteId).throwIfError();
         assertEquals(documentId, document.response().getDocumentId());
         assertNull(document.response().getArtifactId());
+        assertEquals(Boolean.TRUE, document.response().getHasArtifacts());
 
         DocumentArtifact artifact = DocumentArtifact.of(documentId, artifactId);
         var artifactDocument =
@@ -1455,12 +1465,14 @@ public class DocumentsRequestTest extends AbstractApiClientRequestTest {
         assertEquals(documentId, artifactDocument.response().getDocumentId());
         assertEquals(artifactId, artifactDocument.response().getArtifactId());
         assertEquals(expectedFilename, artifactDocument.response().getPath());
+        assertEquals(Boolean.FALSE, artifactDocument.response().getHasArtifacts());
 
         var artifacts = new GetDocumentArtifactsRequestBuilder(documentId).submit(client, siteId)
             .throwIfError();
         List<Document> documents = notNull(artifacts.response().getDocuments());
         assertEquals(1, documents.size());
         assertEquals(artifactId, documents.getFirst().getArtifactId());
+        assertEquals(Boolean.FALSE, documents.getFirst().getHasArtifacts());
 
         var folders = new GetFoldersRequestBuilder().submit(client, siteId).response();
         var filenames = notNull(folders.getDocuments()).stream().map(SearchResultDocument::getPath)

--- a/docs/openapi/openapi-iam.yaml
+++ b/docs/openapi/openapi-iam.yaml
@@ -9644,6 +9644,9 @@ components:
         artifactId:
           type: string
           description: Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type
@@ -9836,6 +9839,9 @@ components:
         artifactId:
           type: string
           description: Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         siteId:
           type: string
           description: Site Identifier
@@ -9919,6 +9925,9 @@ components:
         documentId:
           type: string
           description: Document Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type
@@ -13221,6 +13230,9 @@ components:
         artifactId:
           type: string
           description: Document Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type

--- a/docs/openapi/openapi-jwt.yaml
+++ b/docs/openapi/openapi-jwt.yaml
@@ -9644,6 +9644,9 @@ components:
         artifactId:
           type: string
           description: Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type
@@ -9836,6 +9839,9 @@ components:
         artifactId:
           type: string
           description: Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         siteId:
           type: string
           description: Site Identifier
@@ -9919,6 +9925,9 @@ components:
         documentId:
           type: string
           description: Document Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type
@@ -13221,6 +13230,9 @@ components:
         artifactId:
           type: string
           description: Document Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type

--- a/docs/openapi/openapi-key.yaml
+++ b/docs/openapi/openapi-key.yaml
@@ -9644,6 +9644,9 @@ components:
         artifactId:
           type: string
           description: Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type
@@ -9836,6 +9839,9 @@ components:
         artifactId:
           type: string
           description: Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         siteId:
           type: string
           description: Site Identifier
@@ -9919,6 +9925,9 @@ components:
         documentId:
           type: string
           description: Document Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type
@@ -13221,6 +13230,9 @@ components:
         artifactId:
           type: string
           description: Document Artifact Identifier
+        hasArtifacts:
+          type: boolean
+          description: Whether the document has artifact documents
         contentType:
           type: string
           description: Document Content-Type

--- a/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/AttributeValueToDocumentItem.java
+++ b/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/AttributeValueToDocumentItem.java
@@ -110,6 +110,8 @@ public class AttributeValueToDocumentItem
     item.setArtifactId((String) map.get("artifactId"));
     item.setBelongsToDocumentId((String) map.get("belongsToDocumentId"));
     item.setChecksumType((String) map.get("checksumType"));
+    item.setHasArtifacts(
+        item.getArtifactId() == null ? (Boolean) map.get("hasArtifacts") : Boolean.FALSE);
 
     item.setVersion(getString(attrs.get("version")));
     item.setS3version(getString(attrs.get(DocumentVersionService.S3VERSION_ATTRIBUTE)));

--- a/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/DocumentItemDynamoDb.java
+++ b/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/DocumentItemDynamoDb.java
@@ -91,6 +91,9 @@ public class DocumentItemDynamoDb implements DocumentItem {
   /** Document Height. */
   @Reflectable
   private String height;
+  /** Whether this non-artifact document has artifact documents. */
+  @Reflectable
+  private Boolean hasArtifacts;
 
   /** constructor. */
   public DocumentItemDynamoDb() {}
@@ -155,6 +158,11 @@ public class DocumentItemDynamoDb implements DocumentItem {
   }
 
   @Override
+  public Boolean getHasArtifacts() {
+    return this.hasArtifacts;
+  }
+
+  @Override
   public String getHeight() {
     return this.height;
   }
@@ -207,6 +215,9 @@ public class DocumentItemDynamoDb implements DocumentItem {
   @Override
   public void setArtifactId(final String id) {
     this.artifactId = id;
+    if (id != null) {
+      this.hasArtifacts = Boolean.FALSE;
+    }
   }
 
   @Override
@@ -247,6 +258,11 @@ public class DocumentItemDynamoDb implements DocumentItem {
   @Override
   public void setDocuments(final List<DocumentItem> objects) {
     this.documents = objects;
+  }
+
+  @Override
+  public void setHasArtifacts(final Boolean documentHasArtifacts) {
+    this.hasArtifacts = this.artifactId == null ? documentHasArtifacts : Boolean.FALSE;
   }
 
   @Override

--- a/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/DocumentItemToDynamicDocumentItem.java
+++ b/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/DocumentItemToDynamicDocumentItem.java
@@ -68,6 +68,7 @@ public class DocumentItemToDynamicDocumentItem
     map.put("contentType", item.getContentType());
     map.put("artifactId", item.getArtifactId());
     map.put("documentId", item.getDocumentId());
+    map.put("hasArtifacts", item.getArtifactId() == null ? item.getHasArtifacts() : Boolean.FALSE);
     map.put("insertedDate", item.getInsertedDate());
     map.put("lastModifiedDate", item.getLastModifiedDate());
     map.put("path", item.getPath());

--- a/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/DocumentServiceImpl.java
+++ b/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/DocumentServiceImpl.java
@@ -58,6 +58,7 @@ import com.formkiq.aws.dynamodb.documents.DocumentRestoreMoveAttributeFunction;
 import com.formkiq.aws.dynamodb.documents.ExistsDocumentById;
 import com.formkiq.aws.dynamodb.documents.FindDocumentById;
 import com.formkiq.aws.dynamodb.documents.GetChildDocumentsQuery;
+import com.formkiq.aws.dynamodb.documents.GetDocumentArtifactsQuery;
 import com.formkiq.aws.dynamodb.documents.GetSoftDeletedDocumentsQuery;
 import com.formkiq.aws.dynamodb.documents.SoftDeleteDocumentQuery;
 import com.formkiq.aws.dynamodb.documents.StoredDerivedAttribute;
@@ -110,6 +111,7 @@ import com.formkiq.validation.ValidationErrorImpl;
 import com.formkiq.validation.ValidationException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
@@ -470,6 +472,11 @@ public final class DocumentServiceImpl implements DocumentService, DbKeys {
 
     if (!softDelete && deleted.deleted() && document.artifactId() == null) {
       this.versionsService.deleteAllVersionIds(siteId, document);
+    }
+
+    if (deleted.deleted() && document.artifactId() != null) {
+      updateDocumentHasArtifacts(siteId, document.documentId(),
+          hasArtifactDocuments(siteId, document));
     }
 
     // check if folder index exists
@@ -1556,6 +1563,8 @@ public final class DocumentServiceImpl implements DocumentService, DbKeys {
             new WriteRequestBuilder().append(this.documentTableName, record.getAttributes(siteId));
 
         writeBuilder.batchWriteItem(this.dbClient);
+      } else {
+        updateDocumentHasArtifacts(siteId, documentId, Boolean.TRUE);
       }
     }
 
@@ -1613,9 +1622,17 @@ public final class DocumentServiceImpl implements DocumentService, DbKeys {
     if (previous != null) {
       builder.lastModifiedDate(new Date());
       builder.setDefaultValues(previous);
+    } else if (documentArtifact.artifactId() == null && item.hasArtifacts() == null) {
+      builder.hasArtifacts(Boolean.FALSE);
     }
 
     return builder;
+  }
+
+  private boolean hasArtifactDocuments(final String siteId, final DocumentArtifact document) {
+    QueryResult response = new GetDocumentArtifactsQuery(document.documentId()).query(dbService,
+        dbService.getTableName(), siteId, null, 1);
+    return !response.items().isEmpty();
   }
 
   /**
@@ -1721,6 +1738,10 @@ public final class DocumentServiceImpl implements DocumentService, DbKeys {
 
     saveDocumentInternal(siteId, documentRecordSet, options);
 
+    if (!isEmpty(documentRecord.artifactId())) {
+      updateDocumentHasArtifacts(siteId, documentId, Boolean.TRUE);
+    }
+
     for (DocumentRecordSet childDoc : notNull(documentRecordSet.children())) {
 
       SaveDocumentOptions childLinkOptions = new SaveDocumentOptions().saveDocumentDate(false)
@@ -1756,8 +1777,21 @@ public final class DocumentServiceImpl implements DocumentService, DbKeys {
       final DocumentRecord documentRecord) {
     var record =
         DocumentRecord.builder().document(DocumentArtifact.of(documentRecord.documentId(), null))
-            .path(documentRecord.path()).userId(documentRecord.userId()).build(siteId);
+            .path(documentRecord.path()).userId(documentRecord.userId()).hasArtifacts(Boolean.TRUE)
+            .build(siteId);
     return new DocumentRecordSet(record, null, null, null);
+  }
+
+  private void updateDocumentHasArtifacts(final String siteId, final String documentId,
+      final Boolean hasArtifacts) {
+    DocumentArtifact document = DocumentArtifact.of(documentId, null);
+
+    if (exists(siteId, document)) {
+      DynamoDbKey key = new DocumentRecordBuilder().document(document).buildKey(siteId);
+      Map<String, AttributeValueUpdate> updateValues = Map.of("hasArtifacts",
+          AttributeValueUpdate.builder().value(AttributeValue.fromBool(hasArtifacts)).build());
+      this.dbService.updateItem(fromS(key.pk()), fromS(key.sk()), updateValues);
+    }
   }
 
   private DocumentRecordSet createChildDocumentLink(final String siteId,

--- a/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/documents/Document.java
+++ b/domain/documents/src/main/java/com/formkiq/stacks/dynamodb/documents/Document.java
@@ -74,6 +74,8 @@ public class Document implements DocumentItem {
   private String width;
   /** Height. */
   private String height;
+  /** Whether this non-artifact document has artifact documents. */
+  private Boolean hasArtifacts;
 
   /**
    * constructor.
@@ -123,6 +125,11 @@ public class Document implements DocumentItem {
   @Override
   public List<DocumentItem> getDocuments() {
     return this.documents;
+  }
+
+  @Override
+  public Boolean getHasArtifacts() {
+    return this.hasArtifacts;
   }
 
   @Override
@@ -178,6 +185,9 @@ public class Document implements DocumentItem {
   @Override
   public void setArtifactId(final String id) {
     this.artifactId = id;
+    if (id != null) {
+      this.hasArtifacts = Boolean.FALSE;
+    }
   }
 
   @Override
@@ -218,6 +228,11 @@ public class Document implements DocumentItem {
   @Override
   public void setDocuments(final List<DocumentItem> childDocuments) {
     this.documents = childDocuments;
+  }
+
+  @Override
+  public void setHasArtifacts(final Boolean documentHasArtifacts) {
+    this.hasArtifacts = this.artifactId == null ? documentHasArtifacts : Boolean.FALSE;
   }
 
   @Override

--- a/src/main/resources/cloudformation/api/partials/paths/documents.yaml
+++ b/src/main/resources/cloudformation/api/partials/paths/documents.yaml
@@ -351,6 +351,9 @@ components:
         artifactId:
           type: "string"
           description: "Artifact Identifier"
+        hasArtifacts:
+          type: "boolean"
+          description: "Whether the document has artifact documents"
         contentType:
           type: "string"
           description: "Document Content-Type"

--- a/src/main/resources/cloudformation/api/partials/paths/documents_id.yaml
+++ b/src/main/resources/cloudformation/api/partials/paths/documents_id.yaml
@@ -138,6 +138,9 @@ components:
         artifactId:
           type: "string"
           description: "Artifact Identifier"
+        hasArtifacts:
+          type: "boolean"
+          description: "Whether the document has artifact documents"
         siteId:
           type: "string"
           description: "Site Identifier"
@@ -223,6 +226,9 @@ components:
         documentId:
           type: "string"
           description: "Document Identifier"
+        hasArtifacts:
+          type: "boolean"
+          description: "Whether the document has artifact documents"
         contentType:
           type: "string"
           description: "Document Content-Type"

--- a/src/main/resources/cloudformation/api/partials/paths/search.yaml
+++ b/src/main/resources/cloudformation/api/partials/paths/search.yaml
@@ -499,6 +499,9 @@ components:
         artifactId:
           type: "string"
           description: "Document Artifact Identifier"
+        hasArtifacts:
+          type: "boolean"
+          description: "Whether the document has artifact documents"
         contentType:
           type: "string"
           description: "Document Content-Type"


### PR DESCRIPTION
- Track hasArtifacts across document records, items, and API models
- Update hasArtifacts when artifacts are added or deleted
- Expose hasArtifacts in document and search OpenAPI schemas
- Add ArtifactStatus as a reserved attribute key
- Add/update tests for artifact state and reserved attribute lookup